### PR TITLE
feat: allow to update help shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Here's the default mapping object for reference:
 		-- Close the UI
 		close = 'q',
 		-- Open the help menu
-		help = 'h', -- Not rebindable
+		help = 'h',
 	},
 	-- Flag to enable directory-scoped bookmark persistence
 	enable_persist = false,

--- a/lua/spelunk/config.lua
+++ b/lua/spelunk/config.lua
@@ -24,6 +24,7 @@ local default_config = {
 		delete_stack = 'D',
 		edit_stack = 'E',
 		close = 'q',
+		help = 'h',
 	},
 	enable_persist = false,
 	statusline_prefix = '🔖',

--- a/lua/spelunk/ui.lua
+++ b/lua/spelunk/ui.lua
@@ -194,6 +194,7 @@ function M.show_help()
 		'Edit stack              ' .. window_config.edit_stack,
 		'Close                   ' .. window_config.close,
 		'Help                    ' .. 'h',
+		'Help                    ' .. window_config.help,
 	}
 	vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, content)

--- a/lua/spelunk/ui.lua
+++ b/lua/spelunk/ui.lua
@@ -261,7 +261,7 @@ function M.create_windows(max_stack_size)
 	set(window_config.edit_stack, ':lua require("spelunk").edit_current_stack()<CR>',
 		'[spelunk.nvim] Edit the name of the current stack')
 	set(window_config.close, ':lua require("spelunk").close_windows()<CR>', '[spelunk.nvim] Close UI')
-	set('h', ':lua require("spelunk").show_help()<CR>', '[spelunk.nvim] Show help menu')
+	set(window_config.help, ':lua require("spelunk").show_help()<CR>', '[spelunk.nvim] Show help menu')
 
 	for i = 1, max_stack_size do
 		set(tostring(i), string.format(':lua require("spelunk").goto_bookmark_at_index(%d)<CR>', i),

--- a/lua/spelunk/ui.lua
+++ b/lua/spelunk/ui.lua
@@ -193,7 +193,6 @@ function M.show_help()
 		'Delete stack            ' .. window_config.delete_stack,
 		'Edit stack              ' .. window_config.edit_stack,
 		'Close                   ' .. window_config.close,
-		'Help                    ' .. 'h',
 		'Help                    ' .. window_config.help,
 	}
 	vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })


### PR DESCRIPTION
This PR allows to set a custom shortcut instead of 'h' for the help menu.
It should close https://github.com/EvWilson/spelunk.nvim/issues/11