### PR TITLE
Refactor marks

### DIFF
--- a/lua/spelunk/config.lua
+++ b/lua/spelunk/config.lua
@@ -33,7 +33,7 @@ local default_config = {
 
 ---@param target table
 ---@param defaults table
-local function apply_defaults(target, defaults)
+local apply_defaults = function(target, defaults)
 	for key, value in pairs(defaults) do
 		if target[key] == nil then
 			target[key] = value
@@ -43,18 +43,18 @@ local function apply_defaults(target, defaults)
 end
 
 ---@param target table
-function M.apply_base_defaults(target)
+M.apply_base_defaults = function(target)
 	apply_defaults(target, default_config.base_mappings)
 end
 
 ---@param target table
-function M.apply_window_defaults(target)
+M.apply_window_defaults = function(target)
 	apply_defaults(target, default_config.window_mappings)
 end
 
 ---@param key string
 ---@return any
-function M.get_default(key)
+M.get_default = function(key)
 	return default_config[key]
 end
 

--- a/lua/spelunk/init.lua
+++ b/lua/spelunk/init.lua
@@ -109,12 +109,9 @@ function M.close_help()
 end
 
 function M.add_bookmark()
-	local current_file = vim.fn.expand('%:p')
-	local current_line = vim.fn.line('.')
-	local vmark = marks.set_mark_current_pos()
-	table.insert(bookmark_stacks[current_stack_index].bookmarks, vmark)
-	print("[spelunk.nvim] Bookmark added to stack '" ..
-		bookmark_stacks[current_stack_index].name .. "': " .. current_file .. ":" .. current_line)
+	table.insert(bookmark_stacks[current_stack_index].bookmarks, marks.set_mark_current_pos())
+	print(string.format("[spelunk.nvim] Bookmark added to stack '%s': %s:%d:%d",
+		bookmark_stacks[current_stack_index].name, vim.fn.expand('%:p'), vim.fn.line('.'), vim.fn.col('.')))
 	update_window()
 	M.persist()
 end
@@ -265,7 +262,7 @@ end
 
 function M.persist()
 	if enable_persist then
-		persist.save(bookmark_stacks)
+		persist.save(marks.virt_to_physical_stack(bookmark_stacks))
 	end
 end
 

--- a/lua/spelunk/init.lua
+++ b/lua/spelunk/init.lua
@@ -374,6 +374,28 @@ function M.setup(c)
 		'[spelunk.nvim] Fuzzy find bookmarks')
 	set(base_config.search_current_bookmarks, tele.extensions.spelunk.current_marks,
 		'[spelunk.nvim] Fuzzy find bookmarks in current stack')
+
+	-- Create a callback to persist changes to mark locations on file updates
+	local persist_augroup = vim.api.nvim_create_augroup('SpelunkPersistCallback', { clear = true })
+	vim.api.nvim_create_autocmd('BufWritePost', {
+		group = persist_augroup,
+		pattern = '*',
+		callback = function(ctx)
+			local bufnr = ctx.buf
+			if not bufnr then
+				return
+			end
+			for _, stack in pairs(bookmark_stacks) do
+				for _, mark in pairs(stack.bookmarks) do
+					if bufnr == mark.bufnr then
+						M.persist()
+						return
+					end
+				end
+			end
+		end,
+		desc = '[spelunk.nvim] Persist mark updates on file change'
+	})
 end
 
 return M

--- a/lua/spelunk/init.lua
+++ b/lua/spelunk/init.lua
@@ -80,13 +80,16 @@ end
 ---@param file string
 ---@param line integer
 ---@param split string | nil
-local function goto_position(file, line, split)
+local function goto_position(file, line, col, split)
 	if not split then
-		vim.cmd('edit +' .. line .. ' ' .. file)
+		vim.api.nvim_command('edit ' .. file)
+		vim.api.nvim_win_set_cursor(0, { line, col })
 	elseif split == 'vertical' then
-		vim.cmd('vsplit +' .. line .. ' ' .. file)
+		vim.api.nvim_command('vsplit ' .. file)
+		vim.api.nvim_win_set_cursor(0, { line, col })
 	elseif split == 'horizontal' then
-		vim.cmd('split +' .. line .. ' ' .. file)
+		vim.api.nvim_command('split ' .. file)
+		vim.api.nvim_win_set_cursor(0, { line, col })
 	else
 		print('[spelunk.nvim] goto_position passed unsupported split: ' .. split)
 	end
@@ -160,7 +163,7 @@ local function goto_bookmark(close, split)
 			M.close_windows()
 		end
 		vim.schedule(function()
-			goto_position(mark.file, mark.line, split)
+			goto_position(mark.file, mark.line, mark.col, split)
 		end)
 	end
 end

--- a/lua/spelunk/init.lua
+++ b/lua/spelunk/init.lua
@@ -279,6 +279,7 @@ function M.all_full_marks()
 				stack = stack.name,
 				file = mark.file,
 				line = mark.line,
+				col = mark.col,
 			})
 		end
 	end
@@ -299,6 +300,7 @@ function M.current_full_marks()
 			stack = stack.name,
 			file = mark.file,
 			line = mark.line,
+			col = mark.col,
 		})
 	end
 	return data

--- a/lua/spelunk/init.lua
+++ b/lua/spelunk/init.lua
@@ -3,7 +3,7 @@ local persist = require('spelunk.persistence')
 
 local M = {}
 
----@type BookmarkStack
+---@type BookmarkStack[]
 local default_stacks = {
 	{ name = 'Default', bookmarks = {} }
 }
@@ -336,6 +336,9 @@ function M.setup(c)
 	if not bookmark_stacks then
 		bookmark_stacks = default_stacks
 	end
+
+	-- EAW TODO mark workspace
+	require('spelunk.mark').setup(bookmark_stacks)
 
 	-- Configure the prefix to use for the lualine integration
 	statusline_prefix = conf.statusline_prefix or cfg.get_default('statusline_prefix')

--- a/lua/spelunk/mark.lua
+++ b/lua/spelunk/mark.lua
@@ -1,0 +1,121 @@
+local M = {}
+
+---@type string
+local ns_name = 'spelunk'
+---@type integer
+local ns_id = vim.api.nvim_create_namespace(ns_name)
+
+---@param filepath string
+---@return integer
+local function get_or_create_buf(filepath)
+	local bufnr = vim.fn.bufnr(filepath)
+	if bufnr == -1 then
+		bufnr = vim.api.nvim_create_buf(false, true)
+		vim.api.nvim_buf_set_name(bufnr, filepath)
+	end
+
+	local success = pcall(function()
+		vim.api.nvim_buf_set_var(bufnr, 'buftype', 'nofile')
+		vim.fn.readfile(filepath)
+		vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.fn.readfile(filepath))
+	end)
+
+	if not success then
+		vim.api.nvim_buf_delete(bufnr, { force = true })
+		return -1
+	end
+	return bufnr
+end
+
+
+---@param mark Bookmark
+---@return integer
+local function set_extmark(mark)
+	local bufnr = get_or_create_buf(mark.file)
+	if bufnr == -1 then
+		error("[spelunk.nvim] set_extmark called for file without buffer")
+	end
+	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, mark.line, 0, {
+		strict = false, -- Allow the mark to move with edits
+		right_gravity = true, -- Mark stays at end of inserted text
+	})
+	return mark_id
+end
+
+---@param stacks BookmarkStack[]
+local function setup_extmarks(stacks)
+	for _, stack in pairs(stacks) do
+		for _, mark in pairs(stack.bookmarks) do
+			local mark_id = set_extmark(mark)
+		end
+	end
+end
+
+---@class AutoCmdArgs
+---@field buf integer
+
+---@param args AutoCmdArgs
+local function on_change(args)
+	local bufnr = args.buf
+	local ems = vim.api.nvim_buf_get_extmarks(0, ns_id, 0, -1, {})
+	print('code changed!')
+end
+
+---@param stacks BookmarkStack
+function M.setup(stacks)
+	setup_extmarks(stacks)
+
+	-- Set callback to update marks on code changes
+	local augroup = vim.api.nvim_create_augroup('SpelunkCodeChangeCallback', { clear = true })
+	vim.api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI' }, {
+		group = augroup,
+		pattern = '*',
+		callback = on_change,
+		desc = '[spelunk.nvim] Trigger callback on code changes'
+	})
+end
+
+-- function M.set_mark_at_current_pos()
+-- 	local bufnr = vim.api.nvim_get_current_buf()
+-- 	local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+-- 	row = row - 1
+--
+-- 	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, row, col, {
+-- 		strict = false, -- Allow the mark to move with edits
+-- 		right_gravity = true, -- Mark stays at end of inserted text
+-- 	})
+--
+-- 	return mark_id
+-- end
+--
+-- function M.set_mark(bufnr, ns_id, row, col)
+-- 	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, row, col, {
+-- 		strict = false, -- Allow the mark to move with edits
+-- 		right_gravity = true, -- Mark stays at end of inserted text
+-- 	})
+--
+-- 	return mark_id
+-- end
+--
+-- function M.get_mark_position(mark_id)
+-- 	local pos = vim.api.nvim_buf_get_extmark_by_id(
+-- 		mark.buffer,
+-- 		ns_id,
+-- 		mark_id,
+-- 		{ details = true }
+-- 	)
+--
+--
+-- 	if not pos or #pos == 0 then
+-- 		return nil, "Mark position not found"
+-- 	end
+--
+-- 	-- Convert to 1-based line number for consistency with Neovim API
+-- 	return {
+-- 		line = pos[1] + 1,
+-- 		col = pos[2],
+-- 		buffer = mark.buffer
+-- 	}
+-- end
+
+return M

--- a/lua/spelunk/mark.lua
+++ b/lua/spelunk/mark.lua
@@ -15,7 +15,6 @@ local function get_or_create_buf(filepath)
 	end
 
 	local success = pcall(function()
-		vim.api.nvim_buf_set_var(bufnr, 'buftype', 'nofile')
 		vim.fn.readfile(filepath)
 		vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.fn.readfile(filepath))
 	end)
@@ -27,10 +26,9 @@ local function get_or_create_buf(filepath)
 	return bufnr
 end
 
-
----@param mark Bookmark
----@return integer
-local function set_extmark(mark)
+---@param mark PhysicalBookmark
+---@return VirtualBookmark
+local function set_virtmark(mark)
 	local bufnr = get_or_create_buf(mark.file)
 	if bufnr == -1 then
 		error("[spelunk.nvim] set_extmark called for file without buffer")
@@ -39,83 +37,35 @@ local function set_extmark(mark)
 		strict = false, -- Allow the mark to move with edits
 		right_gravity = true, -- Mark stays at end of inserted text
 	})
-	return mark_id
+	return {
+		bufnr = bufnr,
+		mark_id = mark_id,
+	}
 end
 
----@param stacks BookmarkStack[]
+---@param virt VirtualBookmark
+---@return PhysicalBookmark
+function M.virt_to_physical(virt)
+	local mark = vim.api.nvim_buf_get_extmark_by_id(virt.bufnr, ns_id, virt.mark_id, {})
+	return {
+		file = vim.api.nvim_buf_get_name(virt.bufnr),
+		line = mark[1],
+		col = mark[2],
+	}
+end
+
+---@param stacks PhysicalStack[]
 local function setup_extmarks(stacks)
 	for _, stack in pairs(stacks) do
 		for _, mark in pairs(stack.bookmarks) do
-			local mark_id = set_extmark(mark)
+			local virtmark = set_virtmark(mark)
 		end
 	end
 end
 
----@class AutoCmdArgs
----@field buf integer
-
----@param args AutoCmdArgs
-local function on_change(args)
-	local bufnr = args.buf
-	local ems = vim.api.nvim_buf_get_extmarks(0, ns_id, 0, -1, {})
-	print('code changed!')
-end
-
----@param stacks BookmarkStack
+---@param stacks PhysicalStack[]
 function M.setup(stacks)
 	setup_extmarks(stacks)
-
-	-- Set callback to update marks on code changes
-	local augroup = vim.api.nvim_create_augroup('SpelunkCodeChangeCallback', { clear = true })
-	vim.api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI' }, {
-		group = augroup,
-		pattern = '*',
-		callback = on_change,
-		desc = '[spelunk.nvim] Trigger callback on code changes'
-	})
 end
-
--- function M.set_mark_at_current_pos()
--- 	local bufnr = vim.api.nvim_get_current_buf()
--- 	local row, col = unpack(vim.api.nvim_win_get_cursor(0))
--- 	row = row - 1
---
--- 	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, row, col, {
--- 		strict = false, -- Allow the mark to move with edits
--- 		right_gravity = true, -- Mark stays at end of inserted text
--- 	})
---
--- 	return mark_id
--- end
---
--- function M.set_mark(bufnr, ns_id, row, col)
--- 	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, row, col, {
--- 		strict = false, -- Allow the mark to move with edits
--- 		right_gravity = true, -- Mark stays at end of inserted text
--- 	})
---
--- 	return mark_id
--- end
---
--- function M.get_mark_position(mark_id)
--- 	local pos = vim.api.nvim_buf_get_extmark_by_id(
--- 		mark.buffer,
--- 		ns_id,
--- 		mark_id,
--- 		{ details = true }
--- 	)
---
---
--- 	if not pos or #pos == 0 then
--- 		return nil, "Mark position not found"
--- 	end
---
--- 	-- Convert to 1-based line number for consistency with Neovim API
--- 	return {
--- 		line = pos[1] + 1,
--- 		col = pos[2],
--- 		buffer = mark.buffer
--- 	}
--- end
 
 return M

--- a/lua/spelunk/mark.lua
+++ b/lua/spelunk/mark.lua
@@ -28,14 +28,14 @@ M.virt_to_physical_stack = function(virtstacks)
 	return ret
 end
 
+---@param mark PhysicalBookmark
 ---@return VirtualBookmark
-M.set_mark_current_pos = function()
-	local bufnr = vim.api.nvim_get_current_buf()
-	local line = vim.fn.line('.')
-	local col = vim.fn.col('.')
-	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, line, col, {
-		strict = false, -- Allow the mark to move with edits
-		right_gravity = true, -- Mark stays at end of inserted text
+local set_mark = function(mark)
+	local bufnr = vim.fn.bufadd(mark.file)
+	vim.fn.bufload(bufnr)
+	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, mark.line, mark.col, {
+		strict = false,
+		right_gravity = true,
 	})
 	return {
 		bufnr = bufnr,
@@ -43,19 +43,13 @@ M.set_mark_current_pos = function()
 	}
 end
 
----@param mark PhysicalBookmark
 ---@return VirtualBookmark
-local set_mark = function(mark)
-	local bufnr = vim.fn.bufadd(mark.file)
-	vim.fn.bufload(bufnr)
-	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, mark.line, mark.col, {
-		strict = false, -- Allow the mark to move with edits
-		right_gravity = true, -- Mark stays at end of inserted text
+M.set_mark_current_pos = function()
+	return set_mark({
+		file = vim.api.nvim_buf_get_name(0),
+		line = vim.fn.line('.'),
+		col = vim.fn.col('.'),
 	})
-	return {
-		bufnr = bufnr,
-		mark_id = mark_id,
-	}
 end
 
 ---@param stacks PhysicalStack[]

--- a/lua/spelunk/mark.lua
+++ b/lua/spelunk/mark.lua
@@ -14,11 +14,25 @@ M.virt_to_physical = function(virt)
 	}
 end
 
+---@param virtstacks VirtualStack[]
+---@return PhysicalStack[]
+M.virt_to_physical_stack = function(virtstacks)
+	local ret = {}
+	for i, stack in ipairs(virtstacks) do
+		local physstack = { name = virtstacks[i].name, bookmarks = {} }
+		for _, mark in pairs(stack.bookmarks) do
+			table.insert(physstack.bookmarks, M.virt_to_physical(mark))
+		end
+		table.insert(ret, physstack)
+	end
+	return ret
+end
+
 ---@return VirtualBookmark
 M.set_mark_current_pos = function()
 	local bufnr = vim.api.nvim_get_current_buf()
-	local line = vim.fn.line('.') - 1
-	local col = vim.fn.col('.') - 1
+	local line = vim.fn.line('.')
+	local col = vim.fn.col('.')
 	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, line, col, {
 		strict = false, -- Allow the mark to move with edits
 		right_gravity = true, -- Mark stays at end of inserted text

--- a/lua/spelunk/mark.lua
+++ b/lua/spelunk/mark.lua
@@ -1,39 +1,25 @@
 local M = {}
 
----@type string
-local ns_name = 'spelunk'
 ---@type integer
-local ns_id = vim.api.nvim_create_namespace(ns_name)
+local ns_id = vim.api.nvim_create_namespace('spelunk')
 
----@param filepath string
----@return integer
-local function get_or_create_buf(filepath)
-	local bufnr = vim.fn.bufnr(filepath)
-	if bufnr == -1 then
-		bufnr = vim.api.nvim_create_buf(false, true)
-		vim.api.nvim_buf_set_name(bufnr, filepath)
-	end
-
-	local success = pcall(function()
-		vim.fn.readfile(filepath)
-		vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.fn.readfile(filepath))
-	end)
-
-	if not success then
-		vim.api.nvim_buf_delete(bufnr, { force = true })
-		return -1
-	end
-	return bufnr
+---@param virt VirtualBookmark
+---@return PhysicalBookmark
+M.virt_to_physical = function(virt)
+	local mark = vim.api.nvim_buf_get_extmark_by_id(virt.bufnr, ns_id, virt.mark_id, {})
+	return {
+		file = vim.api.nvim_buf_get_name(virt.bufnr),
+		line = mark[1],
+		col = mark[2],
+	}
 end
 
----@param mark PhysicalBookmark
 ---@return VirtualBookmark
-local function set_virtmark(mark)
-	local bufnr = get_or_create_buf(mark.file)
-	if bufnr == -1 then
-		error("[spelunk.nvim] set_extmark called for file without buffer")
-	end
-	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, mark.line, 0, {
+M.set_mark_current_pos = function()
+	local bufnr = vim.api.nvim_get_current_buf()
+	local line = vim.fn.line('.') - 1
+	local col = vim.fn.col('.') - 1
+	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, line, col, {
 		strict = false, -- Allow the mark to move with edits
 		right_gravity = true, -- Mark stays at end of inserted text
 	})
@@ -43,29 +29,34 @@ local function set_virtmark(mark)
 	}
 end
 
----@param virt VirtualBookmark
----@return PhysicalBookmark
-function M.virt_to_physical(virt)
-	local mark = vim.api.nvim_buf_get_extmark_by_id(virt.bufnr, ns_id, virt.mark_id, {})
+---@param mark PhysicalBookmark
+---@return VirtualBookmark
+local set_mark = function(mark)
+	local bufnr = vim.fn.bufadd(mark.file)
+	vim.fn.bufload(bufnr)
+	local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, mark.line, mark.col, {
+		strict = false, -- Allow the mark to move with edits
+		right_gravity = true, -- Mark stays at end of inserted text
+	})
 	return {
-		file = vim.api.nvim_buf_get_name(virt.bufnr),
-		line = mark[1],
-		col = mark[2],
+		bufnr = bufnr,
+		mark_id = mark_id,
 	}
 end
 
 ---@param stacks PhysicalStack[]
-local function setup_extmarks(stacks)
-	for _, stack in pairs(stacks) do
+---@return VirtualStack[]
+M.setup = function(stacks)
+	---@type VirtualStack[]
+	local vstack = {}
+	for idx, stack in ipairs(stacks) do
+		table.insert(vstack, { name = stacks[idx].name, bookmarks = {} })
 		for _, mark in pairs(stack.bookmarks) do
-			local virtmark = set_virtmark(mark)
+			local virtmark = set_mark(mark)
+			table.insert(vstack[idx].bookmarks, virtmark)
 		end
 	end
-end
-
----@param stacks PhysicalStack[]
-function M.setup(stacks)
-	setup_extmarks(stacks)
+	return vstack
 end
 
 return M

--- a/lua/spelunk/persistence.lua
+++ b/lua/spelunk/persistence.lua
@@ -1,6 +1,10 @@
 local M = {}
 
-local state_dir = vim.fs.joinpath(vim.fn.stdpath('state'), 'spelunk')
+local statepath = vim.fn.stdpath('state')
+if type(statepath) == 'table' then
+	statepath = statepath[1]
+end
+local state_dir = vim.fs.joinpath(statepath, 'spelunk')
 local cwd_str = (vim.fn.getcwd() .. '.lua'):gsub('[/\\:*?\"<>|]', '_')
 local path = vim.fs.joinpath(state_dir, cwd_str)
 
@@ -12,7 +16,7 @@ end
 -- savetbl and loadtbl taken from:
 -- http://lua-users.org/wiki/SaveTableToFile
 
----@param tbl BookmarkStack
+---@param tbl PhysicalStack[]
 ---@param filename string
 local function savetbl(tbl, filename)
 	local charS, charE = '   ', '\n'
@@ -78,7 +82,7 @@ local function savetbl(tbl, filename)
 	file:close()
 end
 
----@return BookmarkStack | nil
+---@return PhysicalStack[] | nil
 local function loadtbl(sfile)
 	local ftables, err = loadfile(sfile)
 	if err then return nil end
@@ -101,7 +105,7 @@ local function loadtbl(sfile)
 	return tables[1]
 end
 
----@param tbl BookmarkStack
+---@param tbl PhysicalStack[]
 function M.save(tbl)
 	if vim.fn.isdirectory(state_dir) == 0 then
 		vim.fn.mkdir(state_dir, 'p')
@@ -109,9 +113,24 @@ function M.save(tbl)
 	savetbl(tbl, path)
 end
 
----@return BookmarkStack | nil
+---@return PhysicalStack[] | nil
 function M.load()
 	local tbl = loadtbl(path)
+
+	if tbl == nil then
+		return
+	end
+
+	-- TODO: Remove this eventually
+	-- Stored marks did not originally have column field, this is a soft migration helper
+	for _, v in pairs(tbl) do
+		for _, mark in pairs(v.bookmarks) do
+			if mark.col == nil then
+				mark.col = 0
+			end
+		end
+	end
+
 	return tbl
 end
 

--- a/lua/spelunk/persistence.lua
+++ b/lua/spelunk/persistence.lua
@@ -116,9 +116,8 @@ end
 ---@return PhysicalStack[] | nil
 function M.load()
 	local tbl = loadtbl(path)
-
 	if tbl == nil then
-		return
+		return nil
 	end
 
 	-- TODO: Remove this eventually

--- a/lua/spelunk/telescope.lua
+++ b/lua/spelunk/telescope.lua
@@ -56,7 +56,7 @@ M.search_stacks = function(prompt, data, cb)
 			actions.select_default:replace(function()
 				local selection = action_state.get_selected_entry()
 				actions.close(prompt_bufnr)
-				cb(selection.value.file, selection.value.line)
+				cb(selection.value.file, selection.value.line, selection.value.col)
 			end)
 			return true
 		end,

--- a/lua/spelunk/types.lua
+++ b/lua/spelunk/types.lua
@@ -1,4 +1,4 @@
----@class Bookmark
+---@class PhysicalBookmark
 ---@field file string
 ---@field line integer
 ---@field col integer
@@ -9,9 +9,17 @@
 ---@field line integer
 ---@field col integer
 
----@class BookmarkStack
+---@class PhysicalStack
 ---@field name string
----@field bookmarks Bookmark[]
+---@field bookmarks PhysicalBookmark[]
+---
+---@class VirtualBookmark
+---@field bufnr integer
+---@field mark_id integer
+
+---@class VirtualStack
+---@field name string
+---@field bookmarks VirtualBookmark[]
 
 ---@class CreateWinOpts
 ---@field title string

--- a/lua/spelunk/types.lua
+++ b/lua/spelunk/types.lua
@@ -32,7 +32,7 @@
 ---@field cursor_index integer
 ---@field title string
 ---@field lines string[]
----@field bookmark Bookmark
+---@field bookmark VirtualBookmark
 ---@field max_stack_size integer
 
 ---@class BaseDimensions

--- a/lua/spelunk/types.lua
+++ b/lua/spelunk/types.lua
@@ -1,13 +1,17 @@
 ---@class Bookmark
 ---@field file string
 ---@field line integer
+---@field col integer
 
 ---@class FullBookmark
 ---@field stack string
 ---@field file string
 ---@field line integer
+---@field col integer
 
----@alias BookmarkStack table<string, Bookmark[]>
+---@class BookmarkStack
+---@field name string
+---@field bookmarks Bookmark[]
 
 ---@class CreateWinOpts
 ---@field title string

--- a/lua/spelunk/ui.lua
+++ b/lua/spelunk/ui.lua
@@ -255,7 +255,12 @@ end
 
 ---@param opts UpdateWinOpts
 local function update_preview(opts)
-	local bookmark = require('spelunk.mark').virt_to_physical(opts.bookmark)
+	local bookmark
+	if opts.bookmark then
+		bookmark = require('spelunk.mark').virt_to_physical(opts.bookmark)
+	else
+		bookmark = nil
+	end
 	if not window_ready(preview_window_id) or not bookmark then
 		return
 	end

--- a/lua/spelunk/ui.lua
+++ b/lua/spelunk/ui.lua
@@ -21,6 +21,7 @@ local window_config
 local focus_cb
 local unfocus_cb
 
+---@type string[]
 local border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' }
 
 ---@param id integer
@@ -254,7 +255,7 @@ end
 
 ---@param opts UpdateWinOpts
 local function update_preview(opts)
-	local bookmark = opts.bookmark
+	local bookmark = require('spelunk.mark').virt_to_physical(opts.bookmark)
 	if not window_ready(preview_window_id) or not bookmark then
 		return
 	end
@@ -266,7 +267,7 @@ local function update_preview(opts)
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 	vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
 
-	local ft = vim.filetype.match({ filename = opts.bookmark.file })
+	local ft = vim.filetype.match({ filename = bookmark.file })
 	if ft then
 		vim.bo[bufnr].filetype = ft
 	end


### PR DESCRIPTION
Bookmarks now use `extmarks` during active sessions, as they always should have. This should let them move as code changes are made, along with allowing for other fun features like status column integrations, virtual text, and more.

This is rather fiddly, and not at all helped by the `extmark` API, which leaves a fair few somethings to be desired. I'm expecting this to have a baking period with some issues to iron out.