### PR TITLE
fix(telescope):  handle missing telescope.nvim for search APIs

### DIFF
--- a/lua/spelunk/init.lua
+++ b/lua/spelunk/init.lua
@@ -295,6 +295,10 @@ function M.all_full_marks()
 end
 
 function M.search_marks()
+	if not tele then
+		vim.notify('[spelunk.nvim] Install telescope.nvim to search marks')
+		return
+	end
 	tele.search_marks('[spelunk.nvim] Bookmarks', M.all_full_marks(), goto_position)
 end
 
@@ -315,6 +319,10 @@ function M.current_full_marks()
 end
 
 function M.search_current_marks()
+	if not tele then
+		vim.notify('[spelunk.nvim] Install telescope.nvim to search marks')
+		return
+	end
 	tele.search_marks('[spelunk.nvim] Current Stack', M.current_full_marks(), goto_position)
 end
 

--- a/lua/spelunk/telescope.lua
+++ b/lua/spelunk/telescope.lua
@@ -1,3 +1,8 @@
+local status_ok, _ = pcall(require, "telescope")
+if not status_ok then
+	return false
+end
+
 local pickers = require('telescope.pickers')
 local finders = require('telescope.finders')
 local conf = require('telescope.config').values


### PR DESCRIPTION
Summary:
- Use pcall in `spelunk/telescope.lua` module and return `false` early if telescope.nvim is not installed.
- Notify user and return early on attempted `search_marks` or `search_current_marks` calls

Currently the README indicates Telescope is optional. With this lazy.nvim config:

<details>
<summary>lazy.nvim config, *without* telescope.nvim in `dependencies` table</summary>

```lua
local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
if not vim.loop.fs_stat(lazypath) then
  vim.fn.system({
    "git",
    "clone",
    "--filter=blob:none",
    "https://github.com/folke/lazy.nvim.git",
    "--branch=stable", -- latest stable release
    lazypath,
  })
end
vim.opt.rtp:prepend(lazypath)


require("lazy").setup({
{
  "EvWilson/spelunk.nvim",
  branch = "buffer-delete-restore",
  dir = "~/Documents/GitHub/spelunk.nvim",
  dependencies = {
    "nvim-lua/plenary.nvim",
    -- "nvim-telescope/telescope.nvim",
  },
  lazy = false,
  opts = {
    enable_persist = true,
  },
}
}, {})
```
</details>

I get this error

```
Failed to run `config` for spelunk.nvim

.../Documents/GitHub/spelunk.nvim/lua/spelunk/telescope.lua:1: module 'telescope.pickers' not found:
^Ino field package.preload['telescope.pickers']
^Icache_loader: module 'telescope.pickers' not found
^Icache_loader_lib: module 'telescope.pickers' not found
^Ino file './telescope/pickers.lua'
^Ino file '/home/aceserani/Applications/neovim/.deps/usr/share/luajit-2.1/telescope/pickers.lua'
^Ino file '/usr/local/share/lua/5.1/telescope/pickers.lua'
^Ino file '/usr/local/share/lua/5.1/telescope/pickers/init.lua'
^Ino file '/home/aceserani/Applications/neovim/.deps/usr/share/lua/5.1/telescope/pickers.lua'
^Ino file '/home/aceserani/Applications/neovim/.deps/usr/share/lua/5.1/telescope/pickers/init.lua'
^Ino file './telescope/pickers.so'
^Ino file '/usr/local/lib/lua/5.1/telescope/pickers.so'
^Ino file '/home/aceserani/Applications/neovim/.deps/usr/lib/lua/5.1/telescope/pickers.so'
^Ino file '/usr/local/lib/lua/5.1/loadall.so'
^Ino file './telescope.so'
^Ino file '/usr/local/lib/lua/5.1/telescope.so'
^Ino file '/home/aceserani/Applications/neovim/.deps/usr/lib/lua/5.1/telescope.so'
^Ino file '/usr/local/lib/lua/5.1/loadall.so'

# stacktrace:
  - ~/Documents/GitHub/spelunk.nvim/lua/spelunk/telescope.lua:1
  - ~/Documents/GitHub/spelunk.nvim/lua/spelunk/init.lua:4
  - min.lua:15
```

This PR handles missing telescope gracefully.