### PR TITLE
Configurable inline context

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ If there is functionality you'd like to see added or exposed, please feel free t
 	end
 	```
 
+- `display_inline_mark_function`
+    - Description: display additional details next to bookmarks
+    - Type: `fun(mark: VirtualBookmark): [string, string]`
+	- Returns: text to display and highlight name (e.g. "Comment" or "Function")
+    - Default value:
+    ```lua
+    M.display_inline_mark_function = function(vmark)
+        return { "", "" }
+    end
+    ```
+
 - `setup(config)`
 	- Description: initialize the plugin, should be called to opt-in to default behavior
 	- Parameters:

--- a/lua/spelunk/init.lua
+++ b/lua/spelunk/init.lua
@@ -55,6 +55,12 @@ M.display_function = function(mark)
 	return string.format('%s:%d', M.filename_formatter(mark.file), mark.line)
 end
 
+---@param vmark VirtualBookmark
+---@return [string, string]
+M.display_inline_mark_function = function(vmark)
+    return { "", "" }
+end
+
 ---@return integer
 local max_stack_size = function()
 	local max = 0
@@ -70,13 +76,16 @@ end
 ---@return UpdateWinOpts
 local get_win_update_opts = function()
 	local lines = {}
+    local inline_marks = {}
 	for _, vmark in ipairs(current_stack().bookmarks) do
 		table.insert(lines, M.display_function(vmark))
+        table.insert(inline_marks, M.display_inline_mark_function(vmark))
 	end
 	return {
 		cursor_index = cursor_index,
 		title = current_stack().name,
 		lines = lines,
+        inline_marks = inline_marks,
 		bookmark = current_bookmark(),
 		max_stack_size = max_stack_size(),
 	}

--- a/lua/spelunk/types.lua
+++ b/lua/spelunk/types.lua
@@ -43,6 +43,7 @@
 ---@field cursor_index integer
 ---@field title string
 ---@field lines string[]
+---@field inline_marks [string, string][] # (text, highlight)
 ---@field bookmark VirtualBookmark
 ---@field max_stack_size integer
 

--- a/lua/spelunk/ui.lua
+++ b/lua/spelunk/ui.lua
@@ -318,6 +318,17 @@ function M.update_window(opts)
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, content)
 	vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
 
+    local virt_text_ns = vim.api.nvim_create_namespace("")
+    for line_nr, virt_text in ipairs(opts.inline_marks) do
+        local line, _ = unpack(virt_text)
+        if line ~= "" then
+            vim.api.nvim_buf_set_extmark(
+                bufnr, virt_text_ns, line_nr, 0,
+                { virt_text = { virt_text }, virt_text_pos = "eol", }
+            )
+        end
+    end
+
 	-- Move cursor to the selected line
 	local offset
 	if #opts.lines > 0 then

--- a/lua/spelunk/util.lua
+++ b/lua/spelunk/util.lua
@@ -5,7 +5,6 @@ local M = {}
 M.get_treesitter_context = function(mark)
 	local ok, parser = pcall(vim.treesitter.get_parser, mark.bufnr)
 	if not ok then
-		vim.notify('[spelunk.nvim] get_treesitter_context failed to set up parser: ' .. parser)
 		return ''
 	end
 	local tree = parser:parse()[1]


### PR DESCRIPTION
Hi, I played a little bit with providing more context via virtual text. Treesitter context is great when it works but sometimes it doesn't and it would be great to still have some context visible then. I tried the right aligned virtual text but it wasn't as easy to read as I would like. Long lines can make it hard to determine which right-aligned context corresponds to which line. I ended up going with virtual text appended after the end of line.

This is the config that I use. When possible it shows the treesitter context, otherwise it shows the line in which the bookmark was set.

```lua
spelunk.display_inline_mark_function = function(vmark)
    local physical_mark = marks.virt_to_physical(vmark)
    local ctx = util.get_treesitter_context(vmark)
    if ctx ~= "" then return { ctx, "Function" } end
    local line = vim.fn.getbufline(vmark.bufnr, physical_mark.line)[1]
    line = vim.trim(line or "")
    return { line, "Comment" }
end
```
<img width="709" alt="Screenshot 2024-12-14 at 22 19 17" src="https://github.com/user-attachments/assets/b611a7e9-fbf9-4757-a28e-c0f7d6fe16c2" />

Let me know what you think, I'm happy to make adjustments.