### PR TITLE
Temporarily disable swapfile usage when preloading buffers for extmark setting

### DIFF
--- a/lua/spelunk/mark.lua
+++ b/lua/spelunk/mark.lua
@@ -16,7 +16,10 @@ end
 ---@return VirtualBookmark
 local set_mark = function(mark, idx)
 	local bufnr = vim.fn.bufadd(mark.file)
+	local old_swapfile = vim.o.swapfile
+	vim.o.swapfile = false
 	vim.fn.bufload(bufnr)
+	vim.o.swapfile = old_swapfile
 	local opts = {
 		strict = false,
 		right_gravity = true,


### PR DESCRIPTION
Seeking to address a portion of https://github.com/EvWilson/spelunk.nvim/issues/62, where a detected swapfile error was raised when opening multiple Neovim instances for a directory.