### PR TITLE
Speed up UI, solve a bug in UI after closing the help menu, remove plenary dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ require('lazy').setup({
 	{
 		'EvWilson/spelunk.nvim',
 		dependencies = {
-			'nvim-lua/plenary.nvim',           -- For window drawing utilities
 			'nvim-telescope/telescope.nvim',   -- Optional: for fuzzy search capabilities
 			'nvim-treesitter/nvim-treesitter', -- Optional: for showing grammar context
 		},

--- a/faqs/add_and_show_mark_metadata.md
+++ b/faqs/add_and_show_mark_metadata.md
@@ -6,7 +6,6 @@ Some folks want to add custom aliases for bookmarks. This is a sample setup for 
 {
 	'EvWilson/spelunk.nvim',
 	dependencies = {
-		'nvim-lua/plenary.nvim',
 		'nvim-telescope/telescope.nvim',
 	},
 	config = function()

--- a/faqs/display_treesitter_context.md
+++ b/faqs/display_treesitter_context.md
@@ -16,9 +16,6 @@ If you'd like to change this to display the Treesitter context for the current m
 ```lua
 {
 	'EvWilson/spelunk.nvim',
-	dependencies = {
-		'nvim-lua/plenary.nvim',
-	},
 	config = function()
 		local spelunk = require('spelunk')
 		spelunk.setup()

--- a/faqs/hide_preview.md
+++ b/faqs/hide_preview.md
@@ -6,9 +6,6 @@ Here's an example of leaving the preview UI pane un-rendered, with a sample `laz
 ```lua
 {
 	'EvWilson/spelunk.nvim',
-	dependencies = {
-		'nvim-lua/plenary.nvim',
-	},
 	config = function()
 	local spelunk = require('spelunk')
 	local base_dimensions = function()

--- a/lua/spelunk/ui.lua
+++ b/lua/spelunk/ui.lua
@@ -13,7 +13,6 @@
 ---@field max_stack_size integer
 
 local layout = require("spelunk.layout")
-local popup = require("plenary.popup")
 
 local M = {}
 
@@ -39,8 +38,6 @@ local cursor_character
 local focus_cb
 local unfocus_cb
 
----@type string[]
-local border_chars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
 
 ---@type integer | nil
 M.previous_win_id = nil
@@ -133,19 +130,40 @@ M.setup = function(base_cfg, window_cfg, cursor_char)
 end
 
 ---@param opts CreateWinOpts
-local create_window = function(opts)
-	local bufnr = vim.api.nvim_create_buf(false, true)
-	local win_id = popup.create(bufnr, {
-		title = opts.title,
-		line = opts.line,
-		col = opts.col,
-		minwidth = opts.minwidth,
-		minheight = opts.minheight,
-		borderchars = border_chars,
-	})
-	vim.api.nvim_set_option_value("wrap", false, { win = win_id })
-	vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
-	return bufnr, win_id
+local function create_window(opts)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+
+  local border_chars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
+  local border = {
+    { border_chars[5], "FloatBorder" }, -- top-left
+    { border_chars[1], "FloatBorder" }, -- top
+    { border_chars[6], "FloatBorder" }, -- top-right
+    { border_chars[2], "FloatBorder" }, -- right
+    { border_chars[7], "FloatBorder" }, -- bottom-right
+    { border_chars[3], "FloatBorder" }, -- bottom
+    { border_chars[8], "FloatBorder" }, -- bottom-left
+    { border_chars[4], "FloatBorder" }, -- left
+  }
+
+  -- Window options for nvim_open_win
+  local win_opts = {
+    style = "minimal",
+    relative = "editor",
+    row = opts.line,
+    col = opts.col,
+    width = opts.minwidth,
+    height = opts.minheight,
+    border = border,
+    title = opts.title,
+    title_pos = "center",
+  }
+
+  local win_id = vim.api.nvim_open_win(bufnr, true, win_opts)
+
+  vim.api.nvim_set_option_value("wrap", false, { win = win_id })
+  vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+
+  return bufnr, win_id
 end
 
 M.show_help = function()


### PR DESCRIPTION
The UI window is drawn using `plenary.popup.create()`.
This PR removes `plenary` dependency and instead uses the native `vim.api.nvim_open_win` function.

This:
- fixes a bug where after closing the help menu you were taken back to the buffer, but the UI was still displayed
- makes drawing the UI window instantaneous