### PR TITLE
Update highlighting, fix extmark clear issue

### DIFF
--- a/lua/spelunk/fuzzy/telescope.lua
+++ b/lua/spelunk/fuzzy/telescope.lua
@@ -33,11 +33,13 @@ local file_previewer = previewers.new_buffer_previewer({
 
 		vim.schedule(function()
 			vim.api.nvim_win_set_cursor(self.state.winid, { entry.value.line, 0 })
-			vim.api.nvim_buf_set_extmark(self.state.bufnr, preview_ns_id, entry.value.line - 1, 0, {
-				end_row = entry.value.line,
-				end_col = 0,
-				hl_group = "Search",
-			})
+			vim.hl.range(
+				self.state.bufnr,
+				preview_ns_id,
+				"Search",
+				{ entry.value.line - 1, 0 },
+				{ entry.value.line, 0 }
+			)
 		end)
 	end,
 })

--- a/lua/spelunk/init.lua
+++ b/lua/spelunk/init.lua
@@ -71,9 +71,6 @@ local update_window = function(updated_indices)
 		markmgr.update_indices(current_stack_index)
 	end
 	ui.update_window(get_win_update_opts())
-	if show_status_col then
-		util.set_extmarks_from_stack(markmgr.stacks()[current_stack_index])
-	end
 end
 
 ---@param file string

--- a/lua/spelunk/ui.lua
+++ b/lua/spelunk/ui.lua
@@ -382,12 +382,16 @@ local update_preview = function(opts)
 		vim.bo[bufnr].filetype = ft
 	end
 
-	vim.api.nvim_buf_clear_namespace(bufnr, -1, 0, -1)
-	vim.api.nvim_buf_set_extmark(bufnr, preview_ns_id, opts.bookmark.line - startline, 0, {
-		end_row = opts.bookmark.line - startline + 1,
-		end_col = 0,
-		hl_group = "Search",
-	})
+	vim.api.nvim_buf_clear_namespace(bufnr, preview_ns_id, 0, -1)
+	vim.schedule(function()
+		vim.hl.range(
+			bufnr,
+			preview_ns_id,
+			"Search",
+			{ opts.bookmark.line - startline, 0 },
+			{ opts.bookmark.line - startline + 1, 0 }
+		)
+	end)
 end
 
 ---@param opts UpdateWinOpts

--- a/lua/spelunk/util.lua
+++ b/lua/spelunk/util.lua
@@ -1,39 +1,5 @@
 local M = {}
 
---- Clears the "spelunk" extmark from all open buffers.
----@return nil
-local clear_extmarks = function()
-	local ns_id = vim.api.nvim_create_namespace("spelunk")
-	for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-		if vim.api.nvim_buf_is_loaded(bufnr) then
-			vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
-		end
-	end
-end
-
---- Only show the marks belonging to the current stack.
----@param stack MarkStack
----@return nil
-M.set_extmarks_from_stack = function(stack)
-	clear_extmarks()
-	local ns_id = vim.api.nvim_create_namespace("spelunk")
-
-	for mark_idx, mark in ipairs(stack.marks) do
-		local bufnr = vim.fn.bufnr(mark.file, true) -- get buffer number, load if needed
-		if bufnr and vim.api.nvim_buf_is_loaded(bufnr) then
-			local opts = {
-				strict = false,
-				right_gravity = true,
-				sign_text = tostring(mark_idx),
-			}
-
-			local mark_id = vim.api.nvim_buf_set_extmark(bufnr, ns_id, mark.line - 1, mark.col - 1, opts)
-			mark.bufnr = bufnr
-			mark.extmark_id = mark_id
-		end
-	end
-end
-
 ---@param mark PhysicalBookmark
 ---@return string
 M.get_treesitter_context = function(mark)


### PR DESCRIPTION
- Reverts change that clears extmarks not in current stack in file as they're needed for change tracking
    - Introduced in https://github.com/EvWilson/spelunk.nvim/pull/70
    - Unfortunately breaks the status column decision made there for now
- Updates highlight setting and schedules it in one case where it is needed